### PR TITLE
Update codebase.css

### DIFF
--- a/template/panel/assets/css/codebase.css
+++ b/template/panel/assets/css/codebase.css
@@ -20600,4 +20600,3 @@ div.tagsinput span.tag a:hover {
   opacity: 0.25;
 }
 
-/*# sourceMappingURL=codebase.css.map */


### PR DESCRIPTION
Карта стилей ссылается на не скомпилированные sccs файлы, которые не имеют смысла, но очень загружают инспектор и усложняет отладку стилей в нем, кроме того сам файл не минифицирован, ему не нужна карта.

![изображение](https://user-images.githubusercontent.com/39173640/191600775-75133024-1dc7-4af9-9f32-092b3675ec69.png)
