### PR TITLE
Update api-ips4.php

### DIFF
--- a/Library/api-ips4.php
+++ b/Library/api-ips4.php
@@ -24,7 +24,7 @@ class api {
 		$INFO['sql_driver'] = 'mysql';
         try {
             return new PDO(
-                $INFO['sql_driver'].":host=".$INFO['sql_host'].";dbname=".$INFO['sql_database'].";charset=".$this->dbcoll,
+                $INFO['sql_driver'].":host=".$INFO['sql_host'].";port=".$INFO['sql_port'].";dbname=".$INFO['sql_database'].";charset=".$this->dbcoll,
                 $INFO['sql_user'],
                 $INFO['sql_pass']
             );


### PR DESCRIPTION
Если на хостинге несколько версий баз данных, то при использовании базы данных, которая не установлена по умолчанию, необходимо указывать порт, которого в запросе нет.